### PR TITLE
mm/sc 1263/update timelines ephemeral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Timelines
 
+## 0.2.3 (2024-04-01)
+### Changed
+- Added active_at scope and active_at? instance method to Ephemeral
+
 ## 0.1.3 (2023-10-09)
 ### Changed
 - Updated the required rails version to "~> 7.1.0"

--- a/lib/timelines/ephemeral.rb
+++ b/lib/timelines/ephemeral.rb
@@ -7,6 +7,7 @@ module Timelines
     included do
       scope :draft, -> { where(started_at: nil) }
       scope :active, -> { where(ended_at: nil, started_at: [..Time.current]) }
+      scope :active_at, ->(date) { where("started_at <= ? and ended_at IS ? OR ended_at >= ?", date, nil, date) }
       scope :with_deleted, -> { unscope(where: :ended_at) }
       scope :ended, -> { where.not(ended_at: nil) }
       scope :deleted, -> { ended }
@@ -14,6 +15,10 @@ module Timelines
 
       def active?
         started? && !ended?
+      end
+
+      def active_at?(date)
+        !!self.class.active_at(date).where(id: self.id)
       end
 
       def start!

--- a/lib/timelines/version.rb
+++ b/lib/timelines/version.rb
@@ -1,3 +1,3 @@
 module Timelines
-  VERSION = "0.1.3"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
This PR updates `Timelines::Ephemeral` with the following:
- an `active_at` scope to return all records that were active at a given date
- an `activate_at?` instance method to return `true` or `false` based on whether the record was activate at a given date 