### PR TITLE
Create HasAuditTrail concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Timelines
 
+## 0.3.3 (2024-05-27)
+### Changed
+- Added audit_trail instance method
+
 ## 0.2.3 (2024-04-01)
 ### Changed
 - Added active_at scope and active_at? instance method to Ephemeral

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Timelines
 
-## 0.3.3 (2024-05-27)
+## 0.3.0 (2024-05-27)
 ### Changed
 - Added audit_trail instance method
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timelines (0.3.3)
+    timelines (0.3.0)
       rails (~> 7.1.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timelines (0.2.3)
+    timelines (0.3.3)
       rails (~> 7.1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ include Timelines::Ephemeral
 
 This gives you the following Instance methods:
 ```ruby
+# Returns an AuditTrail object containing the resource and any associated events, in chronological order
+.audit_trail
+
+# Returns an AuditTrail object containing the resource and any associated events, in reverse order
+.audit_trail(reverse: true)
+
 # Returns a boolean indicating whether the record is currently active
 .active?
 

--- a/lib/timelines.rb
+++ b/lib/timelines.rb
@@ -1,6 +1,8 @@
 require "timelines/version"
 require "timelines/models/concerns/ephemeral"
 require "timelines/models/concerns/has_events"
+require "timelines/models/concerns/has_audit_trail"
+require "timelines/models/concerns/audit_trail"
 require "timelines/models/event"
 
 module Timelines

--- a/lib/timelines/models/concerns/audit_trail.rb
+++ b/lib/timelines/models/concerns/audit_trail.rb
@@ -1,0 +1,15 @@
+module Timelines
+  class AuditTrail
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :resource
+    attribute :reverse
+    attribute :events
+
+    def events
+      reverse ? resource.events.reverse : resource.events
+    end
+  end
+end

--- a/lib/timelines/models/concerns/has_audit_trail.rb
+++ b/lib/timelines/models/concerns/has_audit_trail.rb
@@ -1,0 +1,11 @@
+require "active_support/concern"
+
+module Timelines
+  module HasAuditTrail
+    extend ActiveSupport::Concern
+
+    def audit_trail(reverse: false)
+      ::Timelines::AuditTrail.new(resource: self, reverse: reverse)
+    end
+  end
+end

--- a/lib/timelines/version.rb
+++ b/lib/timelines/version.rb
@@ -1,3 +1,3 @@
 module Timelines
-  VERSION = "0.2.3"
+  VERSION = "0.3.3"
 end

--- a/lib/timelines/version.rb
+++ b/lib/timelines/version.rb
@@ -1,3 +1,3 @@
 module Timelines
-  VERSION = "0.3.3"
+  VERSION = "0.3.0"
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   include Timelines::HasEvents
+  include Timelines::HasAuditTrail
   include Timelines::Ephemeral
   attribute :started_at, :datetime, default: -> { Time.current }
 

--- a/spec/lib/models/concerns/audit_trail_spec.rb
+++ b/spec/lib/models/concerns/audit_trail_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+module Timelines
+  describe AuditTrail, type: :model do
+    let(:mock_resource) { build(:user) }
+
+    describe "#events" do
+      let(:mock_events) {
+        [
+          {event: "first"},
+          {event: "second"},
+          {event: "third"}
+        ]
+      }
+
+      before { allow(mock_resource).to receive(:events).and_return mock_events }
+
+      it "returns events in chronological order" do
+        expect(mock_resource.audit_trail.events).to eq mock_events
+      end
+
+      it "returns events in reverse order" do
+        expect(mock_resource.audit_trail(reverse: true).events).to eq mock_events.reverse
+      end
+    end
+
+    describe "#resource" do
+      it "returns the resource" do
+        expect(mock_resource.audit_trail.resource).to eq mock_resource
+      end
+    end
+  end
+end

--- a/spec/lib/models/concerns/has_audit_trail_spec.rb
+++ b/spec/lib/models/concerns/has_audit_trail_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+module Timelines
+  describe HasAuditTrail do
+    let(:mock_resource) { build(:user) }
+
+    it "returns an audit trail object" do
+      expect(mock_resource.audit_trail).to be_an_instance_of ::Timelines::AuditTrail
+    end
+  end
+end


### PR DESCRIPTION
# What does this do?

Adds an `AuditTrail` model and a `HasAuditTrail` module. When a resource includes this module, we can call `.audit_trail` on it to get back an object that contains the `resource` and its `events`. By default, the events associated with the audit trail are returned in chronological order. However, we can call `.audit_trail(reverse: true).events` to retrieve the events in reverse order.