### PR TITLE
Update Ephemeral scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Timelines
 
+## 0.4.0 (2024-08-06)
+### Changed
+- Updated the `active_at`, `ended`, and `not_deleted` scopes to return live records that may have future end dates.
+- Calling `end!` on a record with a future end date will now set the end date to the current date.
+
 ## 0.3.1 (2024-06-17)
 ### Changed
 - Modified the `destroy` method to run callbacks, remove associations, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timelines (0.3.1)
+    timelines (0.4.0)
       rails (~> 7.1.0)
 
 GEM

--- a/lib/timelines/models/concerns/ephemeral.rb
+++ b/lib/timelines/models/concerns/ephemeral.rb
@@ -6,12 +6,12 @@ module Timelines
 
     included do
       scope :draft, -> { where(started_at: nil) }
-      scope :active, -> { where(ended_at: nil, started_at: [..Time.current]) }
-      scope :active_at, ->(date) { where("started_at <= ? AND (ended_at IS ? OR ended_at >= ?)", date, nil, date) }
+      scope :active, -> { active_at(Time.current) }
+      scope :active_at, ->(date) { where(started_at: [..date], ended_at: nil).or(where(started_at: [..date], ended_at: [date..])) }
       scope :with_deleted, -> { unscope(where: :ended_at) }
-      scope :ended, -> { where.not(ended_at: nil) }
+      scope :ended, -> { where(ended_at: [..Time.current]) }
       scope :deleted, -> { ended }
-      scope :not_deleted, -> { where(ended_at: nil) }
+      scope :not_deleted, -> { where(ended_at: nil).or(where(ended_at: [Time.current..])) }
 
       def active?
         started? && !ended?
@@ -32,7 +32,7 @@ module Timelines
       end
 
       def end!
-        return self if ended_at.present?
+        return self if ended_at.present? && ended_at.past?
 
         result = ActiveRecord::Base.transaction do
           run_callbacks(:destroy) do

--- a/lib/timelines/version.rb
+++ b/lib/timelines/version.rb
@@ -1,3 +1,3 @@
 module Timelines
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
- Updated the `active_at`, `ended`, and `not_deleted` scopes to return live records that may have future end dates.
- Calling `end!` on a record with a future end date will now set the end date to the current date.